### PR TITLE
Add Gas Estimator Protocol in order to let users write their own gas estimator

### DIFF
--- a/Sources/swift4337/gas-estimator/GasEstimatorProtocol.swift
+++ b/Sources/swift4337/gas-estimator/GasEstimatorProtocol.swift
@@ -1,0 +1,29 @@
+//
+//  GasEstimatorProtocol.swift
+//  
+//
+//  Created by Frederic DE MATOS on 02/07/2024.
+//
+
+import Foundation
+import BigInt
+
+public enum GasEstimatorError: Error, Equatable {
+    case invalidLatestBaseFeePerGas
+    case cannotCalculateMaxBaseFee
+}
+
+public struct GasFee {
+    public let maxFeePerGas: BigUInt
+    public let maxPriorityFeePerGas: BigUInt
+}
+
+
+public protocol GasEstimatorProtocol {
+    var baseFeePercentMultiplier: Int {get}
+    var priorityFeePercentMultiplier: Int {get}
+    var minBaseFee:BigUInt {get}
+    var minPriorityFee: BigUInt {get}
+    
+    func getGasFees() async throws -> GasFee
+}

--- a/Sources/swift4337/smart-account/SmartAccountProtocol.swift
+++ b/Sources/swift4337/smart-account/SmartAccountProtocol.swift
@@ -31,6 +31,7 @@ public protocol SmartAccountProtocol {
     
     var address: EthereumAddress {get}
     var signer: EthereumAccount {get}
+    var gasEstimator: GasEstimatorProtocol {get}
     
     var rpc: EthereumRPCProtocol {get}
     var bundler: BundlerClientProtocol {get}
@@ -83,7 +84,6 @@ extension SmartAccountProtocol{
                                           factoryData: factoryData,
                                           callData: callData.web3.hexString)
         
-        let gasEstimator = RPCGasEstimator(self.rpc)
         let gasFee = try await gasEstimator.getGasFees()
         
         userOperation.maxFeePerGas = gasFee.maxFeePerGas.web3.hexString

--- a/Sources/swift4337/smart-account/safe/SafeAccount.swift
+++ b/Sources/swift4337/smart-account/safe/SafeAccount.swift
@@ -22,7 +22,9 @@ public struct SafeAccount: SmartAccountProtocol  {
   
     public var entryPointAddress: EthereumAddress
     
-    public init(address: EthereumAddress? = nil, signer: EthereumAccount, rpc: EthereumRPCProtocol, bundler: BundlerClientProtocol, paymaster: PaymasterClientProtocol? = nil, safeConfig: SafeConfig = SafeConfig.entryPointV7()) async throws {
+    public let gasEstimator: GasEstimatorProtocol
+    
+    public init(address: EthereumAddress? = nil, signer: EthereumAccount, rpc: EthereumRPCProtocol, bundler: BundlerClientProtocol, paymaster: PaymasterClientProtocol? = nil, safeConfig: SafeConfig = SafeConfig.entryPointV7(), gasEstimator: GasEstimatorProtocol? = nil) async throws {
         if let address {
             self.address = address
         } else {
@@ -38,6 +40,14 @@ public struct SafeAccount: SmartAccountProtocol  {
         self.chainId = rpc.network.intValue
         
         self.entryPointAddress = EthereumAddress(self.safeConfig.entryPointAddress)
+        
+        if let estimator = gasEstimator{
+            self.gasEstimator = estimator
+        } else {
+            self.gasEstimator = RPCGasEstimator(rpc)
+        }
+            
+        
     }
     
 

--- a/Tests/swift4337Tests/gas-estimator/RPCGasEstimatorTests.swift
+++ b/Tests/swift4337Tests/gas-estimator/RPCGasEstimatorTests.swift
@@ -24,7 +24,8 @@ class RPCGasEstimatorTests: XCTestCase {
     
     
     func testGetGasFeesWithBaseMultiplier100AndPriorityMultiplier100IsOK() async throws {
-        let gasFee = try await gasEstimator.getGasFees(baseFeePercentMultiplier: 100, priorityFeePercentMultiplier: 100)
+        let gasEstimator = RPCGasEstimator(TestRPCClient(network: EthereumNetwork.sepolia), baseFeePercentMultiplier: 100, priorityFeePercentMultiplier: 100)
+        let gasFee = try await gasEstimator.getGasFees()
         
         // (0x155a4548 + 0x59682f00 + 0x3b9aca00 + 0x59682f00 + 0x59682f00) / 5
         XCTAssertEqual(gasFee.maxPriorityFeePerGas, BigUInt(1171647502))
@@ -32,10 +33,33 @@ class RPCGasEstimatorTests: XCTestCase {
     }
     
     func testGetGasFeesWithDefautReturnBaseTime2AndPriorityTimeOnePoint2IsOK() async throws {
+        let gasEstimator = RPCGasEstimator(TestRPCClient(network: EthereumNetwork.sepolia))
         let gasFee = try await gasEstimator.getGasFees()
         
         // (0x155a4548 + 0x59682f00 + 0x3b9aca00 + 0x59682f00 + 0x59682f00) / 5 * 1.2
         XCTAssertEqual(gasFee.maxPriorityFeePerGas, BigUInt(1405977002).multiplied(by: BigUInt(120).quotientAndRemainder(dividingBy: BigUInt(100)).quotient))
+        
+        XCTAssertEqual(gasFee.maxFeePerGas,
+                       BigUInt(hex: "0xc816c3d2")!.multiplied(by: BigUInt(2)) + gasFee.maxPriorityFeePerGas)
+    }
+    
+    
+    func testGetGasFeesWithMinBaseFeeIsOK() async throws {
+        let gasEstimator = RPCGasEstimator(TestRPCClient(network: EthereumNetwork.sepolia), minBaseFee: BigUInt(300000000000))
+        let gasFee = try await gasEstimator.getGasFees()
+        
+        // (0x155a4548 + 0x59682f00 + 0x3b9aca00 + 0x59682f00 + 0x59682f00) / 5 * 1.2
+        XCTAssertEqual(gasFee.maxPriorityFeePerGas, BigUInt(1405977002).multiplied(by: BigUInt(120).quotientAndRemainder(dividingBy: BigUInt(100)).quotient))
+        
+        XCTAssertEqual(gasFee.maxFeePerGas,
+                       BigUInt(300000000000))
+    }
+    
+    func testGetGasFeesWithMinPriorityFeeIsOK() async throws {
+        let gasEstimator = RPCGasEstimator(TestRPCClient(network: EthereumNetwork.sepolia), minPriorityFee: BigUInt(2000000000))
+        let gasFee = try await gasEstimator.getGasFees()
+        
+        XCTAssertEqual(gasFee.maxPriorityFeePerGas, BigUInt(2000000000))
         
         XCTAssertEqual(gasFee.maxFeePerGas,
                        BigUInt(hex: "0xc816c3d2")!.multiplied(by: BigUInt(2)) + gasFee.maxPriorityFeePerGas)

--- a/Tests/swift4337Tests/smart-account/safe/SafeAccountTests.swift
+++ b/Tests/swift4337Tests/smart-account/safe/SafeAccountTests.swift
@@ -116,4 +116,13 @@ class SafeAccountTests: XCTestCase {
         let owners = try await self.safeAccount.getOwners()
         XCTAssertEqual(owners[0].toChecksumAddress(), account.address.toChecksumAddress())
     }
+    
+    
+    func testInitWalletWithCustomGasEstimatorIsOk() async throws {
+      
+        let gasEstimator = RPCGasEstimator(rpc, minBaseFee: BigUInt(50000000))
+        self.safeAccount = try await SafeAccount(signer: account, rpc: rpc, bundler: bundler, gasEstimator: gasEstimator)
+       
+        XCTAssertEqual(safeAccount.gasEstimator.minBaseFee, BigUInt(50000000))
+    }
 }


### PR DESCRIPTION
This PR introduces several enhancements to improve gas estimation and SafeAccount initialization flexibility.

**Changes**

- Add Gas Estimator Protocol to allow users to write custom gas estimators
- Implemented the Gas Estimator Protocol : Enabled users to define their own gas estimation logic
- Enhance SafeAccount initialization to accept a custom gasEstimator
- Add minBaseFee and minPriorityFee to GasEstimator

