### PR TITLE
Deploy and add passkey signer as owner of the safe

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "e78a02913fcdcf211bfbfa2f49643327f3ce4c0f8e77748d5ee789bba7326a9f",
+  "originHash" : "9b0bf9e838bf1c65785753c152740afff93a88e001cda77697877b77b6113081",
   "pins" : [
     {
       "identity" : "bigint",

--- a/Sources/swift4337/signer/passkey/SafePasskeySigner.swift
+++ b/Sources/swift4337/signer/passkey/SafePasskeySigner.swift
@@ -23,7 +23,7 @@ public class SafePasskeySigner:NSObject, PasskeySignerProtocol {
     
     public let domain: String
     public let name: String
-    public let address: EthereumAddress;
+    public var address: EthereumAddress;
    
     public var authorizationDelegate: AuthorizationDelegate = AuthorizationDelegate()
     
@@ -35,10 +35,11 @@ public class SafePasskeySigner:NSObject, PasskeySignerProtocol {
         super.init()
     }
     
-    public init(domain: String, name: String, address: EthereumAddress = EthereumAddress(SafeConfig.entryPointV7().safeWebAuthnSharedSignerAddress)) async throws{
+    public init(domain: String, name: String, isSharedWebauthnSigner:Bool = true, safeConfig: SafeConfig = SafeConfig.entryPointV7()) async throws{
         self.domain = domain
         self.name = name
-        self.address = address
+        self.address = EthereumAddress.zero
+       
         self.publicKey = PublicKey(x: "", y: "")
         super.init()
        
@@ -48,6 +49,15 @@ public class SafePasskeySigner:NSObject, PasskeySignerProtocol {
         }
         
         self.publicKey = publicKey
+        
+        if (isSharedWebauthnSigner == true) {
+            self.address = EthereumAddress(safeConfig.safeWebAuthnSharedSignerAddress)
+        } else {
+            let verifiers = EthereumAddress(safeConfig.safeP256VerifierAddress).asNumber()!
+          
+            let getSignerFunction = GetSignerFunction(contract:  EthereumAddress(safeConfig.safeWebauthnSignerFactory), x: self.publicX, y: self.publicY, verifiers: verifiers)
+          
+        }
     }
     
     public func formatSignature (_ signature: Data) -> String {

--- a/Sources/swift4337/signer/passkey/SafePasskeySigner.swift
+++ b/Sources/swift4337/signer/passkey/SafePasskeySigner.swift
@@ -15,6 +15,8 @@ import BigInt
 
 public enum PasskeySignerError: Error, Equatable {
     case errorNotImplemented
+    case errorGetSignerAddress
+    case errorMissingRPCCLient
 }
 
 public class SafePasskeySigner:NSObject, PasskeySignerProtocol {
@@ -24,6 +26,7 @@ public class SafePasskeySigner:NSObject, PasskeySignerProtocol {
     public let domain: String
     public let name: String
     public var address: EthereumAddress;
+    
    
     public var authorizationDelegate: AuthorizationDelegate = AuthorizationDelegate()
     
@@ -35,28 +38,35 @@ public class SafePasskeySigner:NSObject, PasskeySignerProtocol {
         super.init()
     }
     
-    public init(domain: String, name: String, isSharedWebauthnSigner:Bool = true, safeConfig: SafeConfig = SafeConfig.entryPointV7()) async throws{
+    public init(domain: String, name: String,  isSharedWebauthnSigner:Bool = true, safeConfig: SafeConfig = SafeConfig.entryPointV7(), rpc: EthereumRPCProtocol? = nil) async throws{
         self.domain = domain
         self.name = name
         self.address = EthereumAddress.zero
-       
+        
         self.publicKey = PublicKey(x: "", y: "")
         super.init()
        
-        guard let publicKey = try self.getPublicKeyFromUserPref() else {
+        if let publicKey = try self.getPublicKeyFromUserPref()  {
+            self.publicKey = publicKey
+        } else {
             self.publicKey = try await self.createPasskey(domain: domain, name: name)
-            return
         }
-        
-        self.publicKey = publicKey
         
         if (isSharedWebauthnSigner == true) {
             self.address = EthereumAddress(safeConfig.safeWebAuthnSharedSignerAddress)
         } else {
             let verifiers = EthereumAddress(safeConfig.safeP256VerifierAddress).asNumber()!
           
-            let getSignerFunction = GetSignerFunction(contract:  EthereumAddress(safeConfig.safeWebauthnSignerFactory), x: self.publicX, y: self.publicY, verifiers: verifiers)
+            guard let rpcClient = rpc else {
+                Logger.defaultLogger.error("Error no RPC Provided ")
+                throw PasskeySignerError.errorMissingRPCCLient
+            }
+            
+            let functionGetSigner =  GetSignerFunction(contract:  EthereumAddress(safeConfig.safeWebauthnSignerFactory), x: self.publicX, y: self.publicY, verifiers: verifiers)
           
+            
+            self.address = try await functionGetSigner.call(withClient:rpcClient , responseType: GetSignerResponse.self).value
+            
         }
     }
     

--- a/Sources/swift4337/smart-account/SmartAccountProtocol.swift
+++ b/Sources/swift4337/smart-account/SmartAccountProtocol.swift
@@ -53,7 +53,8 @@ public protocol SmartAccountProtocol {
     func getCallData(to: EthereumAddress, value:BigUInt, data:Data) throws -> Data
     func getOwners() async throws -> [EthereumAddress]
     func signUserOperation(_ userOperation: UserOperation) async throws -> Data
-    func deployAndEnablePasskeySigner() async throws -> EthereumAddress
+    func deployAndEnablePasskeySigner(x:BigUInt, y:BigUInt) async throws -> String 
+    func addOwner(address: EthereumAddress) async throws -> String
 }
 
 extension SmartAccountProtocol{

--- a/Sources/swift4337/smart-account/SmartAccountProtocol.swift
+++ b/Sources/swift4337/smart-account/SmartAccountProtocol.swift
@@ -53,6 +53,7 @@ public protocol SmartAccountProtocol {
     func getCallData(to: EthereumAddress, value:BigUInt, data:Data) throws -> Data
     func getOwners() async throws -> [EthereumAddress]
     func signUserOperation(_ userOperation: UserOperation) async throws -> Data
+    func deployAndEnablePasskeySigner() async throws -> EthereumAddress
 }
 
 extension SmartAccountProtocol{

--- a/Sources/swift4337/smart-account/safe/SafeABIFunctions.swift
+++ b/Sources/swift4337/smart-account/safe/SafeABIFunctions.swift
@@ -144,3 +144,43 @@ public struct GetOwnersResponse: ABIResponse, MulticallDecodableResponse {
            self.value = try values[0].decodedArray()
        }
    }
+
+
+//function getOwners() public view override returns (address[] memory) {
+struct AddOwnerWithThresholdFunction: ABIFunction {
+        public static let name = "addOwnerWithThreshold"
+        public let gasPrice: BigUInt?
+        public let gasLimit: BigUInt?
+        public var contract: EthereumAddress
+        public let from: EthereumAddress?
+    
+        public let owner: EthereumAddress
+        public let _threshold: BigUInt
+    
+
+        public init(
+            contract: EthereumAddress,
+            from: EthereumAddress? = nil,
+            gasPrice: BigUInt? = nil,
+            gasLimit: BigUInt? = nil,
+            owner: EthereumAddress,
+            _threshold: BigUInt
+        ) {
+            self.contract = contract
+            self.from = from
+            self.gasPrice = gasPrice
+            self.gasLimit = gasLimit
+            
+            self.owner = owner
+            self._threshold = _threshold
+
+        }
+
+        public func encode(to encoder: ABIFunctionEncoder) throws {
+            try encoder.encode(owner)
+            try encoder.encode(_threshold)
+        }
+   }
+
+
+

--- a/Sources/swift4337/smart-account/safe/SafeAccount.swift
+++ b/Sources/swift4337/smart-account/safe/SafeAccount.swift
@@ -115,6 +115,11 @@ public struct SafeAccount: SmartAccountProtocol  {
         return createProxyWithNonceData
     }
     
+    public func deployAndEnablePasskeySigner() async throws -> EthereumAddress {
+        
+        return EthereumAddress.zero
+    }
+    
 
     
     public static func predictAddress(signer: SignerProtocol, rpc: EthereumRPCProtocol, safeConfig: SafeConfig) async throws -> EthereumAddress {
@@ -138,5 +143,8 @@ public struct SafeAccount: SmartAccountProtocol  {
         let predictedAddress = try Create2.getCreate2Address(from: safeConfig.proxyFactory, salt: saltNonce.bytes, initCodeHash: keccack256DeploymentCode.bytes)
         return EthereumAddress(predictedAddress)
     }
+    
+    
+
  
 }

--- a/Sources/swift4337/smart-account/safe/SafeConfig.swift
+++ b/Sources/swift4337/smart-account/safe/SafeConfig.swift
@@ -18,6 +18,7 @@ public struct SafeConfig {
     public var safeWebAuthnSharedSignerAddress: String
     public var safeMultiSendAddress: String
     public var safeP256VerifierAddress: String
+    public var safeWebauthnSignerFactory: String
     public var creationNonce = BigUInt(0)
     
     init(safeSingletonL2: String,
@@ -28,6 +29,7 @@ public struct SafeConfig {
                 safeWebAuthnSharedSignerAddress: String,
                 safeMultiSendAddress: String,
                 safeP256VerifierAddress: String,
+                safeWebauthnSignerFactory: String,
                 creationNonce: BigUInt = BigUInt(0)) {
         self.safeSingletonL2 = safeSingletonL2
         self.proxyFactory = proxyFactory
@@ -38,6 +40,7 @@ public struct SafeConfig {
         self.safeWebAuthnSharedSignerAddress = safeWebAuthnSharedSignerAddress
         self.safeMultiSendAddress = safeMultiSendAddress
         self.safeP256VerifierAddress = safeP256VerifierAddress
+        self.safeWebauthnSignerFactory = safeWebauthnSignerFactory
     }
     
     public static func entryPointV7() ->SafeConfig{
@@ -48,7 +51,8 @@ public struct SafeConfig {
                           entryPointAddress: "0x0000000071727De22E5E9d8BAf0edAc6f37da032",
                           safeWebAuthnSharedSignerAddress: "0xfD90FAd33ee8b58f32c00aceEad1358e4AFC23f9",
                           safeMultiSendAddress: "0x38869bf66a61cF6bDB996A6aE40D5853Fd43B526",
-                          safeP256VerifierAddress: "0x445a0683e494ea0c5AF3E83c5159fBE47Cf9e765")
+                          safeP256VerifierAddress: "0x445a0683e494ea0c5AF3E83c5159fBE47Cf9e765",
+                          safeWebauthnSignerFactory: "0xF7488fFbe67327ac9f37D5F722d83Fc900852Fbf")
     }
 }
 

--- a/Sources/swift4337/smart-account/safe/SafeWebAuthnSignerFactoryABIFunction.swift
+++ b/Sources/swift4337/smart-account/safe/SafeWebAuthnSignerFactoryABIFunction.swift
@@ -1,0 +1,97 @@
+//
+//  SafeWebAuthnSignerFactoryABIFunction.swift
+//
+//
+//  Created by Frederic DE MATOS on 29/07/2024.
+//
+
+import Foundation
+import web3
+import BigInt
+import os
+
+
+struct GetSignerFunction: ABIFunction {
+    
+    public static let name = "getSigner"
+    public let gasPrice: BigUInt?
+    public let gasLimit: BigUInt?
+    public var contract: EthereumAddress
+    public let from: EthereumAddress?
+    
+    public let x: BigUInt
+    public let y: BigUInt
+    public let verifiers : BigUInt
+    
+    public init(
+        contract: EthereumAddress,
+        from: EthereumAddress? = nil,
+        gasPrice: BigUInt? = nil,
+        gasLimit: BigUInt? = nil,
+        x:BigUInt,
+        y:BigUInt,
+        verifiers:BigUInt
+    ) {
+        self.contract = contract
+        self.from = from
+        self.gasPrice = gasPrice
+        self.gasLimit = gasLimit
+        
+        self.x = x;
+        self.y = y
+        self.verifiers = verifiers
+    }
+
+    public func encode(to encoder: ABIFunctionEncoder) throws {
+        try encoder.encode(x)
+        try encoder.encode(y)
+        try encoder.encode(verifiers)
+    }
+}
+
+public struct GetSignerResponse: ABIResponse, MulticallDecodableResponse {
+       public static var types: [ABIType.Type] = [ABIArray<EthereumAddress>.self]
+       public let value: [EthereumAddress]
+
+       public init?(values: [ABIDecoder.DecodedValue]) throws {
+           self.value = try values[0].decodedArray()
+       }
+   }
+
+struct CreateSignerFunction: ABIFunction {
+    
+    public static let name = "createSigner"
+    public let gasPrice: BigUInt?
+    public let gasLimit: BigUInt?
+    public var contract: EthereumAddress
+    public let from: EthereumAddress?
+    
+    public let x: BigUInt
+    public let y: BigUInt
+    public let verifiers : BigUInt
+    
+    public init(
+        contract: EthereumAddress,
+        from: EthereumAddress? = nil,
+        gasPrice: BigUInt? = nil,
+        gasLimit: BigUInt? = nil,
+        x:BigUInt,
+        y:BigUInt,
+        verifiers:BigUInt
+    ) {
+        self.contract = contract
+        self.from = from
+        self.gasPrice = gasPrice
+        self.gasLimit = gasLimit
+        
+        self.x = x;
+        self.y = y
+        self.verifiers = verifiers
+    }
+
+    public func encode(to encoder: ABIFunctionEncoder) throws {
+        try encoder.encode(x)
+        try encoder.encode(y)
+        try encoder.encode(verifiers)
+    }
+}

--- a/Sources/swift4337/smart-account/safe/SafeWebAuthnSignerFactoryABIFunction.swift
+++ b/Sources/swift4337/smart-account/safe/SafeWebAuthnSignerFactoryABIFunction.swift
@@ -45,18 +45,18 @@ struct GetSignerFunction: ABIFunction {
     public func encode(to encoder: ABIFunctionEncoder) throws {
         try encoder.encode(x)
         try encoder.encode(y)
-        try encoder.encode(verifiers)
+        try encoder.encode(verifiers, staticSize: 176)
     }
 }
 
 public struct GetSignerResponse: ABIResponse, MulticallDecodableResponse {
-       public static var types: [ABIType.Type] = [ABIArray<EthereumAddress>.self]
-       public let value: [EthereumAddress]
-
-       public init?(values: [ABIDecoder.DecodedValue]) throws {
-           self.value = try values[0].decodedArray()
-       }
-   }
+    public static var types: [ABIType.Type] = [EthereumAddress.self]
+    public let value: EthereumAddress
+    
+    public init?(values: [ABIDecoder.DecodedValue]) throws {
+        self.value = try values[0].decoded()
+    }
+}
 
 struct CreateSignerFunction: ABIFunction {
     
@@ -92,6 +92,6 @@ struct CreateSignerFunction: ABIFunction {
     public func encode(to encoder: ABIFunctionEncoder) throws {
         try encoder.encode(x)
         try encoder.encode(y)
-        try encoder.encode(verifiers)
+        try encoder.encode(verifiers, staticSize: 176)
     }
 }

--- a/Tests/swift4337Tests/smart-account/safe/AddOwnerTests.swift
+++ b/Tests/swift4337Tests/smart-account/safe/AddOwnerTests.swift
@@ -1,0 +1,26 @@
+//
+//  AddOwnerTests.swift
+//  
+//
+//  Created by Frederic DE MATOS on 29/07/2024.
+//
+
+
+import XCTest
+import web3
+import BigInt
+@testable import swift4337
+
+class AddOwnerTests: XCTestCase {
+    
+    func testEncodeAddOwnerWithThresholdIsOk() async throws {
+        let newOwner  = EthereumAddress("0xF64DA4EFa19b42ef2f897a3D533294b892e6d99E")
+        let threshold = BigUInt(1)
+        
+        let addOwnerWithThresholdFunction =  AddOwnerWithThresholdFunction(contract: EthereumAddress.zero, owner: newOwner, _threshold: threshold)
+        let expected = "0x0d582f13000000000000000000000000f64da4efa19b42ef2f897a3d533294b892e6d99e0000000000000000000000000000000000000000000000000000000000000001"
+        
+        XCTAssertEqual(try addOwnerWithThresholdFunction.transaction().data!.web3.hexString, expected)
+        
+    }
+}

--- a/Tests/swift4337Tests/smart-account/safe/SafeAccountTests.swift
+++ b/Tests/swift4337Tests/smart-account/safe/SafeAccountTests.swift
@@ -65,7 +65,7 @@ class SafeAccountTests: XCTestCase {
 
     func testGetCallDataWithOnlyValueIsOk() async throws {
         self.safeAccount = try await SafeAccount(signer: account, rpc: rpc, bundler: bundler)
-        let callData = try safeAccount.getCallData(to: EthereumAddress("0xF64DA4EFa19b42ef2f897a3D533294b892e6d99E"), value: BigUInt(1), data: "0x".web3.hexData!)
+        let callData = try safeAccount.getCallData(to: EthereumAddress("0xF64DA4EFa19b42ef2f897a3D533294b892e6d99E"), value: BigUInt(1), data: "0x".web3.hexData!, delegateCall: false)
         
         let expected = "0x7bb37428000000000000000000000000f64da4efa19b42ef2f897a3d533294b892e6d99e0000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
         
@@ -74,7 +74,7 @@ class SafeAccountTests: XCTestCase {
     
     func testGetCallDataWithDataIsOk() async throws {
         self.safeAccount = try await SafeAccount(signer: account, rpc: rpc, bundler: bundler)
-        let callData = try safeAccount.getCallData(to: EthereumAddress("0x0338Dcd5512ae8F3c481c33Eb4b6eEdF632D1d2f"), value: BigUInt(0), data: "0x06661abd".web3.hexData!)
+        let callData = try safeAccount.getCallData(to: EthereumAddress("0x0338Dcd5512ae8F3c481c33Eb4b6eEdF632D1d2f"), value: BigUInt(0), data: "0x06661abd".web3.hexData!, delegateCall: false)
         
         let expected = "0x7bb374280000000000000000000000000338dcd5512ae8f3c481c33eb4b6eedf632d1d2f000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000800000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000406661abd00000000000000000000000000000000000000000000000000000000"
         

--- a/Tests/swift4337Tests/smart-account/safe/SafeWebAuthnSignerFactoryTests.swift
+++ b/Tests/swift4337Tests/smart-account/safe/SafeWebAuthnSignerFactoryTests.swift
@@ -22,11 +22,29 @@ class SafeWebAuthnSignerFactoryTests: XCTestCase {
         
         let getSignerFunction = GetSignerFunction(contract:  EthereumAddress(config.safeWebauthnSignerFactory), x: x, y: y, verifiers: verifiers)
         
-        let expected = "0x5bb4e6e63628c66b9ba2b579e51e6b7ddcbf7526c0b882678655bde48a7bb1504662a36209f4304a01b5b94bcec32d29dab08f3abc5e305ae05fb953d0372bcb7e752ecc000000000000000000000000445a0683e494ea0c5af3e83c5159fbe47cf9e765"
+        let expected = "0xa541d91a3628c66b9ba2b579e51e6b7ddcbf7526c0b882678655bde48a7bb1504662a36209f4304a01b5b94bcec32d29dab08f3abc5e305ae05fb953d0372bcb7e752ecc000000000000000000000000445a0683e494ea0c5af3e83c5159fbe47cf9e765"
         
         XCTAssertEqual(try getSignerFunction.transaction().data!.web3.hexString, expected)
         
     }
+    
+    func testEncodeGetSigner2IsOk() async throws {
+        let config = SafeConfig.entryPointV7()
+    
+             
+             
+        let x = BigUInt(hex: "0xe0161e5c76f0c4dfa580102899ad0e82b2cb3be0329ec1ae9abb0aa878d4dd3a")!
+        let y = BigUInt(hex: "0xeafbeb6a97b5c782fc3abdf0c61d6576047988420bd38d7b0cd22493e77c35a7")!
+        let verifiers = BigUInt("375087029821578385695419886245161665007891705074112")
+        
+        let getSignerFunction = GetSignerFunction(contract:  EthereumAddress(config.safeWebauthnSignerFactory), x: x, y: y, verifiers: verifiers)
+        
+        let expected = "0xa541d91ae0161e5c76f0c4dfa580102899ad0e82b2cb3be0329ec1ae9abb0aa878d4dd3aeafbeb6a97b5c782fc3abdf0c61d6576047988420bd38d7b0cd22493e77c35a7000000000000000000000100a51c1fc2f0d1a1b8494ed1fe312d7c3a78ed91c0"
+        
+        XCTAssertEqual(try getSignerFunction.transaction().data!.web3.hexString, expected)
+        
+    }
+
     
     func testEncodeCreateSignerIsOk() async throws {
         let config = SafeConfig.entryPointV7()
@@ -37,7 +55,7 @@ class SafeWebAuthnSignerFactoryTests: XCTestCase {
         
         let createSignerFunction = CreateSignerFunction(contract: EthereumAddress(config.safeWebauthnSignerFactory), x: x, y: y, verifiers: verifiers)
         
-        let expected = "0x26a53db83628c66b9ba2b579e51e6b7ddcbf7526c0b882678655bde48a7bb1504662a36209f4304a01b5b94bcec32d29dab08f3abc5e305ae05fb953d0372bcb7e752ecc000000000000000000000000445a0683e494ea0c5af3e83c5159fbe47cf9e765"
+        let expected = "0x0d2f04893628c66b9ba2b579e51e6b7ddcbf7526c0b882678655bde48a7bb1504662a36209f4304a01b5b94bcec32d29dab08f3abc5e305ae05fb953d0372bcb7e752ecc000000000000000000000000445a0683e494ea0c5af3e83c5159fbe47cf9e765"
         
         XCTAssertEqual(try createSignerFunction.transaction().data!.web3.hexString, expected)
         

--- a/Tests/swift4337Tests/smart-account/safe/SafeWebAuthnSignerFactoryTests.swift
+++ b/Tests/swift4337Tests/smart-account/safe/SafeWebAuthnSignerFactoryTests.swift
@@ -1,0 +1,45 @@
+//
+//  SafeWebAuthnSignerFactoryTests.swift
+//
+//
+//  Created by Frederic DE MATOS on 29/07/2024.
+//
+
+import XCTest
+import web3
+import BigInt
+@testable import swift4337
+
+class SafeWebAuthnSignerFactoryTests: XCTestCase {
+    
+    func testEncodeGetSignerIsOk() async throws {
+        let config = SafeConfig.entryPointV7()
+        let verifiers = EthereumAddress(config.safeP256VerifierAddress).asNumber()!
+             
+             
+        let x = BigUInt(hex: "0x3628C66B9BA2B579E51E6B7DDCBF7526C0B882678655BDE48A7BB1504662A362")!
+        let y = BigUInt(hex: "0x9F4304A01B5B94BCEC32D29DAB08F3ABC5E305AE05FB953D0372BCB7E752ECC")!
+        
+        let getSignerFunction = GetSignerFunction(contract:  EthereumAddress(config.safeWebauthnSignerFactory), x: x, y: y, verifiers: verifiers)
+        
+        let expected = "0x5bb4e6e63628c66b9ba2b579e51e6b7ddcbf7526c0b882678655bde48a7bb1504662a36209f4304a01b5b94bcec32d29dab08f3abc5e305ae05fb953d0372bcb7e752ecc000000000000000000000000445a0683e494ea0c5af3e83c5159fbe47cf9e765"
+        
+        XCTAssertEqual(try getSignerFunction.transaction().data!.web3.hexString, expected)
+        
+    }
+    
+    func testEncodeCreateSignerIsOk() async throws {
+        let config = SafeConfig.entryPointV7()
+        let verifiers = EthereumAddress(config.safeP256VerifierAddress).asNumber()!
+             
+        let x = BigUInt(hex: "0x3628C66B9BA2B579E51E6B7DDCBF7526C0B882678655BDE48A7BB1504662A362")!
+        let y = BigUInt(hex: "0x9F4304A01B5B94BCEC32D29DAB08F3ABC5E305AE05FB953D0372BCB7E752ECC")!
+        
+        let createSignerFunction = CreateSignerFunction(contract: EthereumAddress(config.safeWebauthnSignerFactory), x: x, y: y, verifiers: verifiers)
+        
+        let expected = "0x26a53db83628c66b9ba2b579e51e6b7ddcbf7526c0b882678655bde48a7bb1504662a36209f4304a01b5b94bcec32d29dab08f3abc5e305ae05fb953d0372bcb7e752ecc000000000000000000000000445a0683e494ea0c5af3e83c5159fbe47cf9e765"
+        
+        XCTAssertEqual(try createSignerFunction.transaction().data!.web3.hexString, expected)
+        
+    }
+}


### PR DESCRIPTION
 The key changes are as follows:

**New isSharedWebauthnSigner Parameter in SafePasskeySigner Class**:
The class SafePasskeySigner now includes a new parameter, isSharedWebauthnSigner. This parameter can be used to specify whether the WebAuthn signer is shared or should be deployed by the factory.

**New Method deployAndEnablePasskeySigner:**
A new method, deployAndEnablePasskeySigner, has been added to the smart account . This method deploys the Safe Webauthn Contract and adds its address as the owner of the safe. 

**Delegate Call Parameters Added:** :New delegate call parameters have been introduced in the prepareUserOperation and sendUserOperation functions. These parameters offer greater flexibility and control over user operations, allowing for more customized and secure interactions within the system.

**Documentation Update:** The README has been updated to reflect the new features and modifications.


**Example Implementation:**
This example demonstrates the creation of a passkey, initialization of the signer, and deployment of the Safe WebAuthn Contract

```swift
import swift4337
let domain = "sample4337.cometh.io"

let keyStorage = EthereumKeyLocalStorage()
let signer = try EthereumAccount.create(replacing: keyStorage, keystorePassword: "MY_PASSWORD")
var smartAccount = try await SafeAccount(signer: signer, rpc: rpc, bundler: bundler)
let smartAccountAddress = smartAccount.address

// This will create the passkey and initialize the signer with the address calculated by the factory
let signerPasskey = try await SafePasskeySigner(domain: domain, name: "Nouveau Signer 2", isSharedWebauthnSigner: false, rpc: rpc)

// This will deploy the Safe Webauthn Contract and add its address as the owner of the safe
let userOpHash = try await smartAccount.deployAndEnablePasskeySigner(x: signerPasskey.publicX, y: signerPasskey.publicY)

// Now you can use the passkey signer with the safe. Specify the address of the smart account to use the same instance. Otherwise, it will calculate a new safe address based on the signer address
smartAccount = try await SafeAccount(address: smartAccountAddress, signer: signer, rpc: rpc, bundler: bundler)
```
