### PR TITLE
feat: implement recovery module functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,42 @@ Available methods:
 
 - **pm_supportedEntryPoints**: eturns an array of supported EntryPoint addresses.
 
+
+### Recovery module
+
+#### Enable Recovery Module
+
+Swift4337 provides a high-level API to enable the recovery module for a Safe Account.
+
+Here is the API we provide:
+
+```swift
+func enableRecoveryModule(guardianAddress: EthereumAddress, recoveryModuleConfig: RecoveryModuleConfig = RecoveryModuleConfig()): String
+func getCurrentGuardian(delayAddress: EthereumAddress): EthereumAddress?
+func isRecoveryStarted(delayAddress: EthereumAddress): Bool
+func cancelRecovery(delayAddress: EthereumAddress): String
+```
+
+- **enableRecoveryModule**: Enables the recovery module for the safe account by passing the guardian address and the recovery module configuration.
+- **getCurrentGuardian**: Returns the current guardian address (if any) for the delay module.
+- **isRecoveryStarted**: Returns true if the recovery process has started.
+- **cancelRecovery**: Cancels the recovery process (if any).
+
+`RecoveryModuleConfig` describes the configuration used for the recovery module, we provides default values:
+
+Here are the default values used for the recovery module, use `RecoveryModuleConfig.defaultConfig()` to get the default values.
+
+```swift
+  public static func defaultConfig() -> RecoveryModuleConfig{
+      return RecoveryModuleConfig(moduleFactoryAddress: "0x000000000000aDdB49795b0f9bA5BC298cDda236",
+                                  delayModuleAddress: "0xd54895B1121A2eE3f37b502F507631FA1331BED6",
+                                  recoveryCooldown: 86400,
+                                  recoveryExpiration: 604800
+      )
+  }
+```
+
+
 ## Dependencies
 
 Swift4337 is built on top of [web3.swift](https://github.com/argentlabs/web3.swift).

--- a/Sources/swift4337/paymaster/PaymasterClientProtocol.swift
+++ b/Sources/swift4337/paymaster/PaymasterClientProtocol.swift
@@ -67,7 +67,7 @@ public extension PaymasterClientProtocol{
                 throw EthereumClientError.unexpectedReturnValue
             }
         } catch {
-            Logger.defaultLogger.error("pm_sponsorUserOperation error")
+            Logger.defaultLogger.error("pm_supportedEntryPoints error")
             throw failureHandler(error)
         }
     }

--- a/Sources/swift4337/smart-account/safe/SafeABIFunctions.swift
+++ b/Sources/swift4337/smart-account/safe/SafeABIFunctions.swift
@@ -222,6 +222,16 @@ public struct IsValidSignatureResponse: ABIResponse {
     
 }
 
+public struct EnableModuleFunction {
+    public static func callData(
+        moduleAddress: EthereumAddress
+    ) throws -> Data {
+        let encoder = ABIFunctionEncoder("enableModule")
+        try encoder.encode(moduleAddress)
+        return try encoder.encoded()
+    }
+}
+
 
 
 

--- a/Sources/swift4337/smart-account/safe/recovery/DelayModuleABIFunctions.swift
+++ b/Sources/swift4337/smart-account/safe/recovery/DelayModuleABIFunctions.swift
@@ -1,0 +1,144 @@
+import web3
+import Foundation
+import BigInt
+
+struct DeployModuleFunction {
+
+    public static func callData(
+        masterCopy: EthereumAddress,
+        initializer: Data,
+        saltNonce: BigUInt
+    ) throws -> Data {
+        let encoder = ABIFunctionEncoder("deployModule")
+        try encoder.encode(masterCopy)
+        try encoder.encode(initializer)
+        try encoder.encode(saltNonce)
+        return try encoder.encoded()
+    }
+    
+}
+
+// getModulesPaginated(address start, uint256 pageSize) external view override returns (address[] memory array, address next)
+struct GetModulesPaginatedFunction: ABIFunction {
+    public static let name = "getModulesPaginated"
+    public let gasPrice: BigUInt?
+    public let gasLimit: BigUInt?
+    public var contract: EthereumAddress
+    public let from: EthereumAddress?
+    //params
+    public let start: EthereumAddress
+    public let pageSize: BigUInt
+
+    public init(
+        contract: EthereumAddress,
+        from: EthereumAddress? = nil,
+        gasPrice: BigUInt? = nil,
+        gasLimit: BigUInt? = nil,
+        start: EthereumAddress,
+        pageSize: BigUInt
+    ) {
+        self.contract = contract
+        self.from = from
+        self.gasPrice = gasPrice
+        self.gasLimit = gasLimit
+        self.start = start
+        self.pageSize = pageSize
+    }
+
+    public func encode(to encoder: ABIFunctionEncoder) throws {
+        try encoder.encode(start)
+        try encoder.encode(pageSize)
+    }
+
+}
+
+
+public struct GetModulesPaginatedResponse: ABIResponse {
+    public static var types: [ABIType.Type] = [ABIArray<EthereumAddress>.self, EthereumAddress.self]
+    public let array: [EthereumAddress]
+    public let next: EthereumAddress
+
+    public init?(values: [ABIDecoder.DecodedValue]) throws {
+        self.array = try values[0].decodedArray()
+        self.next = try values[1].decoded()
+    }
+}
+
+
+// txNonce() returns (uint256)
+struct TxNonceFunction: ABIFunction {
+    public static let name = "txNonce"
+    public let gasPrice: BigUInt?
+    public let gasLimit: BigUInt?
+    public var contract: EthereumAddress
+    public let from: EthereumAddress?
+
+    public init(
+        contract: EthereumAddress,
+        from: EthereumAddress? = nil,
+        gasPrice: BigUInt? = nil,
+        gasLimit: BigUInt? = nil
+    ) {
+        self.contract = contract
+        self.from = from
+        self.gasPrice = gasPrice
+        self.gasLimit = gasLimit
+    }
+
+    public func encode(to encoder: ABIFunctionEncoder) throws {
+    }
+}
+
+
+public struct TxNonceResponse: ABIResponse {
+    public static var types: [ABIType.Type] = [BigUInt.self]
+    public let value: BigUInt
+
+    public init?(values: [ABIDecoder.DecodedValue]) throws {
+        self.value = try values[0].decoded()
+    }
+}
+
+// queueNonce() returns (uint256)
+struct QueueNonceFunction: ABIFunction {
+    public static let name = "queueNonce"
+    public let gasPrice: BigUInt?
+    public let gasLimit: BigUInt?
+    public var contract: EthereumAddress
+    public let from: EthereumAddress?
+
+    public init(
+        contract: EthereumAddress,
+        from: EthereumAddress? = nil,
+        gasPrice: BigUInt? = nil,
+        gasLimit: BigUInt? = nil
+    ) {
+        self.contract = contract
+        self.from = from
+        self.gasPrice = gasPrice
+        self.gasLimit = gasLimit
+    }   
+
+    public func encode(to encoder: ABIFunctionEncoder) throws {
+    }
+    
+}
+
+public struct QueueNonceResponse: ABIResponse {
+    public static var types: [ABIType.Type] = [BigUInt.self]
+    public let value: BigUInt
+
+    public init?(values: [ABIDecoder.DecodedValue]) throws {
+        self.value = try values[0].decoded()
+    }
+}
+
+struct SetTxNonceFunction  {
+    public static func callData(
+        nonce: BigUInt
+    ) throws -> Data {
+        let encoder = ABIFunctionEncoder("setTxNonce")
+        try encoder.encode(nonce)
+        return try encoder.encoded()
+    }
+}

--- a/Sources/swift4337/smart-account/safe/recovery/DelayModuleUtils.swift
+++ b/Sources/swift4337/smart-account/safe/recovery/DelayModuleUtils.swift
@@ -1,0 +1,54 @@
+
+
+import web3
+import BigInt
+import Foundation
+
+
+extension String {
+    func removeHexPrefix() -> String {
+        return hasPrefix("0x") ? String(dropFirst(2)) : self
+    }
+    func hexStringToKeccak256Bytes() -> [UInt8] {
+        return self.web3.bytesFromHex!.keccak256.web3.bytes
+    }
+}
+
+extension Data {
+    func keccak256Hex() -> String {
+        return self.web3.keccak256.web3.hexString
+    }
+}
+
+public struct DelayModuleUtils {
+    
+    public static func predictAddress(safeAddress: EthereumAddress, config: RecoveryModuleConfig) throws -> EthereumAddress? {
+        let initializer = try getSetUpFunctionData(safeAddress: safeAddress, recoveryModuleConfig: config)
+        let moduleAddress = config.delayModuleAddress.removeHexPrefix()
+        let safeAddressHex = safeAddress.toChecksumAddress().removeHexPrefix().padLeft(toLength: 64, withPad: "0")
+        let initCodeHash = "0x602d8060093d393df3363d3d373d3d3d363d73\(moduleAddress)5af43d82803e903d91602b57fd5bf3".hexStringToKeccak256Bytes()
+        let salt = "\(initializer.keccak256Hex())\(safeAddressHex)".hexStringToKeccak256Bytes()
+        let predictedAddress = try Create2.getCreate2Address(from: config.moduleFactoryAddress, salt: salt, initCodeHash: initCodeHash)
+        return EthereumAddress(predictedAddress)
+    }
+
+    public static func getSetUpFunctionData(safeAddress: EthereumAddress, recoveryModuleConfig: RecoveryModuleConfig) throws -> Data {
+        let initParams = try getInitParams(safeAddress: safeAddress, recoveryModuleConfig: recoveryModuleConfig)
+        let initializer = "0xa4f9edbf000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000a0\(initParams.web3.hexString.removeHexPrefix())"
+        return initializer.web3.hexData!
+    }
+
+    private static func getInitParams(safeAddress: EthereumAddress, recoveryModuleConfig: RecoveryModuleConfig) throws -> Data {
+        let safeAddressData = try ABIEncoder.encode(safeAddress).bytes
+        let recoveryCooldownData = try ABIEncoder.encode(BigUInt(recoveryModuleConfig.recoveryCooldown)).bytes
+        let recoveryExpirationData = try ABIEncoder.encode(BigUInt(recoveryModuleConfig.recoveryExpiration)).bytes
+        let signatureData = [ safeAddressData,
+                              safeAddressData,
+                              safeAddressData,
+                              recoveryCooldownData,
+                              recoveryExpirationData
+        ].flatMap { $0 }
+        return Data(signatureData)
+    }
+
+}

--- a/Sources/swift4337/smart-account/safe/recovery/RecoveryModuleConfig.swift
+++ b/Sources/swift4337/smart-account/safe/recovery/RecoveryModuleConfig.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+public struct RecoveryModuleConfig {
+    public var moduleFactoryAddress: String
+    public var delayModuleAddress: String
+    public var recoveryCooldown: Int
+    public var recoveryExpiration: Int
+
+    public init(
+        moduleFactoryAddress: String,
+        delayModuleAddress: String,
+        recoveryCooldown: Int,
+        recoveryExpiration: Int
+    ) {
+        self.moduleFactoryAddress = moduleFactoryAddress
+        self.delayModuleAddress = delayModuleAddress
+        self.recoveryCooldown = recoveryCooldown
+        self.recoveryExpiration = recoveryExpiration
+    }
+    
+    public static func defaultConfig() -> RecoveryModuleConfig {
+        return RecoveryModuleConfig(moduleFactoryAddress: "0x000000000000aDdB49795b0f9bA5BC298cDda236",
+                                    delayModuleAddress: "0xd54895B1121A2eE3f37b502F507631FA1331BED6",
+                                    recoveryCooldown: 86400,
+                                    recoveryExpiration: 604800
+        )
+    }
+}

--- a/Tests/swift4337Tests/smart-account/recovery/DelayModuleABIFunctionsTests.swift
+++ b/Tests/swift4337Tests/smart-account/recovery/DelayModuleABIFunctionsTests.swift
@@ -1,0 +1,52 @@
+
+import web3
+import XCTest
+import BigInt
+@testable import swift4337
+
+class DelayModuleABIFunctionsTests: XCTestCase {
+    
+    func testDeployModuleFunctionIsOk() throws {
+        let config = RecoveryModuleConfig.defaultConfig()
+        let masterCopy = EthereumAddress(config.delayModuleAddress)
+        let initializer = "0xaaaa".web3.hexData!
+        let saltNonce = BigUInt("0x4bF81EEF3911db0615297836a8fF351f5Fe08c68".web3.hexData!)
+        let delayModuleFactoryCallData = try DeployModuleFunction.callData(masterCopy: masterCopy, initializer: initializer, saltNonce: saltNonce)
+        let expected = "0xf1ab873c000000000000000000000000d54895b1121a2ee3f37b502f507631fa1331bed600000000000000000000000000000000000000000000000000000000000000600000000000000000000000004bf81eef3911db0615297836a8ff351f5fe08c680000000000000000000000000000000000000000000000000000000000000002aaaa000000000000000000000000000000000000000000000000000000000000"
+        XCTAssertEqual(delayModuleFactoryCallData.web3.hexString, expected)
+    }
+
+    func testGetModulesPaginatedFunctionIsOk() throws {
+        let callData = try GetModulesPaginatedFunction(
+            contract: EthereumAddress("0x9b24CE7A4d940920c479f26d9460F6195C1e86ab"), 
+            start: EthereumAddress("0x0000000000000000000000000000000000000000"), 
+            pageSize: BigUInt(100)
+        ).transaction().data
+        XCTAssertEqual(callData?.web3.hexString, "0xcc2f845200000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000064")
+    }
+
+    func testTxNonceFunctionIsOk() throws {
+        let callData = try TxNonceFunction(
+            contract: EthereumAddress("0x9b24CE7A4d940920c479f26d9460F6195C1e86ab"), 
+            from: EthereumAddress("0x0000000000000000000000000000000000000000")
+        ).transaction().data
+        XCTAssertEqual(callData?.web3.hexString, "0xc66323e5")
+    }
+
+    func testQueueNonceFunctionIsOk() throws {
+        let callData = try QueueNonceFunction(
+            contract: EthereumAddress("0x9b24CE7A4d940920c479f26d9460F6195C1e86ab"), 
+            from: EthereumAddress("0x0000000000000000000000000000000000000000")
+        ).transaction().data
+        XCTAssertEqual(callData?.web3.hexString, "0xde8dd91d")
+    }
+
+    func testSetTxNonceFunctionIsOk() throws {
+        let callData = try SetTxNonceFunction.callData(nonce: BigUInt(1))
+        XCTAssertEqual(callData.web3.hexString, "0x46ba23070000000000000000000000000000000000000000000000000000000000000001")
+    }
+
+
+        
+
+}

--- a/Tests/swift4337Tests/smart-account/recovery/DelayModuleUtilsTests.swift
+++ b/Tests/swift4337Tests/smart-account/recovery/DelayModuleUtilsTests.swift
@@ -1,0 +1,15 @@
+import web3
+import XCTest
+import BigInt
+@testable import swift4337
+
+class DelayModuleUtilsTests: XCTestCase {
+    
+    func testPredictDelayModuleAddressIsOk() async throws {
+        let safeAddress = EthereumAddress("0x4bF81EEF3911db0615297836a8fF351f5Fe08c68")
+        let recoveryModuleConfig = RecoveryModuleConfig.defaultConfig()
+        let predictedAddress = try DelayModuleUtils.predictAddress(safeAddress: safeAddress, config: recoveryModuleConfig)
+        XCTAssertEqual(predictedAddress?.toChecksumAddress(), "0x9b24CE7A4d940920c479f26d9460F6195C1e86ab")
+    }
+
+}


### PR DESCRIPTION
### Recovery module

Swift4337 provides a high-level API to enable the recovery module for a Safe Account.

- **enableRecoveryModule**: Enables the recovery module for the safe account by passing the guardian address and the recovery module configuration.
- **getCurrentGuardian**: Returns the current guardian address (if any) for the delay module.
- **isRecoveryStarted**: Returns true if the recovery process has started.
- **cancelRecovery**: Cancels the recovery process (if any).